### PR TITLE
Improvements for large file handling and video height inference

### DIFF
--- a/main.js
+++ b/main.js
@@ -214,6 +214,87 @@ ipcMain.handle('createTorrent', async (event, files, pieceLength) => {
       'udp://utracker.ghostchu-services.top:6969'
     ];
 
+    const readablePromiseForStream = async function (stream) {
+      return new Promise((resolve, _) => {
+        stream.on('readable', () => { resolve(); });
+      });
+    };
+
+    const generatePieces = async function (files) {
+      const pieces = [];
+
+      let pieceHashStream = crypto.createHash('sha1');
+
+      // Represents the number of bytes still needed to complete the piece
+      // currently being accumulated in pieceHashStream.
+      // If 0, pieceHashStream is effectively "empty" or has just been reset
+      // after completing a piece.
+      let bytesNeededForSpanningPiece = 0;
+
+      let currentFileReadOffset = 0;
+
+      for (let i = 0; i < files.length; ++i) {
+        const filePath = files[i];
+
+        if (bytesNeededForSpanningPiece > 0) {
+          const headStream = fs.createReadStream(filePath, {
+            highWaterMark: pieceLength,
+            start: 0,
+            end: bytesNeededForSpanningPiece - 1,
+          });
+          await readablePromiseForStream(headStream);
+
+          let chunkToCompletePiece = headStream.read(bytesNeededForSpanningPiece);
+          if (chunkToCompletePiece === null) {
+            // If the file is smaller than `bytesNeededForSpanningPiece`,
+            // theoretically read again will give back content in buffer.
+            // But it doesn't work while debugging (always return null),
+            // so fallback to try reading with actual readable length.
+            const bytesToRead = Math.min(bytesNeededForSpanningPiece, headStream.readableLength);
+            chunkToCompletePiece = headStream.read(bytesToRead);
+          }
+          headStream.destroy();
+          pieceHashStream.update(chunkToCompletePiece);
+
+          if (chunkToCompletePiece.length < bytesNeededForSpanningPiece) {
+            bytesNeededForSpanningPiece -= chunkToCompletePiece.length;
+
+            currentFileReadOffset = 0;
+            continue;
+          } else {
+            pieces.push(pieceHashStream.digest());
+
+            pieceHashStream = crypto.createHash('sha1');
+            bytesNeededForSpanningPiece = 0;
+
+            currentFileReadOffset = chunkToCompletePiece.length;
+          }
+        }
+
+        const mainReadStream = fs.createReadStream(files[i], {
+          highWaterMark: pieceLength,
+          start: currentFileReadOffset,
+        });
+        currentFileReadOffset = 0;
+
+        for await (const chunk of mainReadStream) {
+          if (chunk.length === pieceLength) {
+            const hash = crypto.createHash('sha1').update(chunk).digest();
+            pieces.push(hash);
+          } else {
+            pieceHashStream.update(chunk);
+            bytesNeededForSpanningPiece = pieceLength - chunk.length;
+          }
+        }
+      }
+
+      if (bytesNeededForSpanningPiece != 0) {
+        pieces.push(pieceHashStream.digest());
+      }
+
+      return Buffer.concat(pieces);
+    };
+
     const torrent = {
       announce: defaultTrackers[0],
       'announce-list': [defaultTrackers],
@@ -222,20 +303,7 @@ ipcMain.handle('createTorrent', async (event, files, pieceLength) => {
         name: torrentName,
         ...(files.length === 1 ? {
           length: fs.statSync(files[0]).size,
-          pieces: (() => {
-            const data = fs.readFileSync(files[0]);
-            const pieces = [];
-            let offset = 0;
-            
-            while (offset < data.length) {
-              const pieceData = data.slice(offset, offset + pieceLength);
-              const hash = crypto.createHash('sha1').update(pieceData).digest();
-              pieces.push(hash);
-              offset += pieceLength;
-            }
-            
-            return Buffer.concat(pieces);
-          })()
+          pieces: await generatePieces(files)
         } : {
           files: files.map(file => {
             console.log('Processing file:', file);
@@ -249,33 +317,10 @@ ipcMain.handle('createTorrent', async (event, files, pieceLength) => {
             };
           }),
           // Generate pieces
-          pieces: (() => {
-          const pieces = [];
-          let piece = Buffer.alloc(0);
-          
-          for (const file of files) {
-            const data = fs.readFileSync(file);
-            piece = Buffer.concat([piece, data]);
-            
-            while (piece.length >= pieceLength) {
-              const pieceData = piece.slice(0, pieceLength);
-              const hash = crypto.createHash('sha1').update(pieceData).digest();
-              pieces.push(hash);
-              piece = piece.slice(pieceLength);
-            }
-          }
-          
-          // Add remaining data if any
-          if (piece.length > 0) {
-            const hash = crypto.createHash('sha1').update(piece).digest();
-            pieces.push(hash);
-          }
-          
-          return Buffer.concat(pieces);
-        })()
-      })
-    }
-  }
+          pieces: await generatePieces(files)
+        })
+      }
+    };
 
     console.log('Created torrent structure:', torrent);
 

--- a/renderer.js
+++ b/renderer.js
@@ -169,6 +169,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       expireDate.setDate(expireDate.getDate() + 30);
       const formattedExpireDate = `${expireDate.getFullYear()}-${String(expireDate.getMonth() + 1).padStart(2, '0')}-${String(expireDate.getDate()).padStart(2, '0')}`;
 
+      // Guess video height from filename, defaults to 1080
+      var videoHeight = '1080';
+      const guessedHeights = selectedFiles.map(file => file.match(/\[\d+P\]/)).filter(x => x);
+      if (guessedHeights.length != 0) {
+        videoHeight = guessedHeights[0][0].slice(1, -2);
+      }
+
       const templateData = {
         magnetLink: torrentInfo.magnetLink,
         torrentFile: torrentInfo.torrentFileName,
@@ -179,6 +186,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         title: document.getElementById('title').value,
         isMovie: document.getElementById('isMovie').checked,
         episode: document.getElementById('episode').value,
+        videoHeight: videoHeight,
         releaseType: document.getElementById('releaseType').value
       };
 

--- a/templates/alliance-content.hbs
+++ b/templates/alliance-content.hbs
@@ -1,4 +1,4 @@
-名侦探柯南 {{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}} {{releaseType}}
+名侦探柯南 {{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}} {{videoHeight}}P {{releaseType}}
 
 制作组：APTX4869字幕组
 发布组：APTX分流组

--- a/templates/alliance-title.hbs
+++ b/templates/alliance-title.hbs
@@ -1,1 +1,1 @@
-[APTX4869][CONAN][名侦探柯南 {{#if isMovie}}MOVIE {{episode}}{{else}}{{episode}}{{/if}} {{title}}][{{#if isMovie}}BDRIP{{else}}HDTV{{/if}}][1080P][{{releaseType}}]
+[APTX4869][CONAN][名侦探柯南 {{#if isMovie}}MOVIE {{episode}}{{else}}{{episode}}{{/if}} {{title}}][{{#if isMovie}}BDRIP{{else}}HDTV{{/if}}][{{videoHeight}}P][{{releaseType}}]

--- a/templates/forum-content.hbs
+++ b/templates/forum-content.hbs
@@ -1,4 +1,4 @@
-名侦探柯南 {{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}} {{releaseType}}
+名侦探柯南 {{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}} {{videoHeight}}P {{releaseType}}
 
 制作组：APTX4869字幕组
 发布组：APTX分流组

--- a/templates/forum-title.hbs
+++ b/templates/forum-title.hbs
@@ -1,1 +1,1 @@
-[APTX4869][CONAN][{{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}}][1080P][{{releaseType}}]
+[APTX4869][CONAN][{{#if isMovie}}剧场版{{episode}}{{else}}第{{episode}}话{{/if}} {{title}}][{{videoHeight}}P][{{releaseType}}]


### PR DESCRIPTION
- Refactored file reading and hash generation with `fs.ReadStream` API, supporting files larger than 2GB.
- Auto match video height from filenames (fallback to 1080 if no matches), and include it in publish templates.